### PR TITLE
Only write definition header on the first visit

### DIFF
--- a/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Writer.java
+++ b/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Writer.java
@@ -15,6 +15,11 @@ public class UnpickV2Writer implements Visitor
 	@Override
 	public void startVisit()
 	{
+		if (writeBuffer.length() != 0)
+		{
+			return;
+		}
+
 		writeBuffer.append("v2\n");
 	}
 	


### PR DESCRIPTION
I have the following groovy code to merge a number of unpick files into a single file for distrubtion

```groovy
def writer = new UnpickV2Writer()

file("unpick-definitions").eachFile {
	new UnpickV2Reader(it.newInputStream()).withCloseable {
		it.accept(writer)
	}
}

output.text = writer.output
```

The existsing code adds the `v2` header for each input, this changes the writer to only write the header if the buffer is empty. It may be prefered to add a boolean and check that, but this fix is minimal.
